### PR TITLE
Add theme selector with system option

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,11 @@
         <!-- Navigation buttons and theme toggle -->
         <div class="flex items-center justify-between mb-4">
             <a href="map.html" class="nav-button">מעבר למפה הכוללת של הטיול</a>
-            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+            <select id="theme-select" class="theme-select" aria-label="Theme selector">
+                <option value="light">בהיר</option>
+                <option value="dark">כהה</option>
+                <option value="system">מערכת</option>
+            </select>
         </div>
         <!-- Main heading -->
         <header class="text-center mb-8">

--- a/map.html
+++ b/map.html
@@ -16,7 +16,11 @@
         <div class="container">
             <!-- Header with theme toggle and navigation back to main page -->
             <div class="map-header">
-                <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+                <select id="theme-select" class="theme-select" aria-label="Theme selector">
+                    <option value="light">בהיר</option>
+                    <option value="dark">כהה</option>
+                    <option value="system">מערכת</option>
+                </select>
                 <a href="index.html" class="nav-button">חזרה לעמוד הראשי</a>
             </div>
             <!-- Embedded Google Map for the itinerary -->

--- a/style.css
+++ b/style.css
@@ -74,28 +74,24 @@ body {
     color: var(--text-color);
 }
 
-/* Theme toggle button */
-.theme-toggle {
-    padding: 0.6rem;
-    font-size: 1.25rem;
+/* Theme selection dropdown */
+.theme-select {
+    padding: 0.4rem 0.6rem;
+    font-size: 1rem;
     border-radius: 0.75rem;
     border: 1px solid var(--nav-button-border);
     background-color: var(--nav-button-bg);
     color: var(--nav-button-color);
-    display: flex;
-    align-items: center;
-    justify-content: center;
     cursor: pointer;
     box-shadow: 0 1px 4px rgba(15, 118, 110, 0.15);
-    transition: background-color 0.2s, color 0.2s, transform 0.2s;
+    transition: background-color 0.2s, color 0.2s;
 }
 
-.theme-toggle:hover,
-.theme-toggle:focus {
+.theme-select:hover,
+.theme-select:focus {
     background-color: var(--nav-button-hover-bg);
     color: var(--nav-button-hover-color);
     border-color: var(--nav-button-hover-border);
-    transform: scale(1.05);
 }
 
 /* גובה/פריסה בקארד כמו המפה הסכמטית */

--- a/theme.js
+++ b/theme.js
@@ -1,17 +1,17 @@
-// Handle light/dark theme switching and persist user preference
+// Handle light/dark/system theme selection and persist user preference
 document.addEventListener('DOMContentLoaded', () => {
     const body = document.body;
-    const toggle = document.getElementById('theme-toggle');
+    const select = document.getElementById('theme-select');
     const STORAGE_KEY = 'theme';
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-    // Apply chosen theme classes and update toggle icon
+    // Apply chosen theme classes based on mode
     function applyTheme(mode) {
-        if (mode === 'dark') {
+        const theme = mode === 'system' ? (prefersDark.matches ? 'dark' : 'light') : mode;
+        if (theme === 'dark') {
             body.classList.add('dark-mode', 'dark');
-            toggle.textContent = '☀️';
         } else {
             body.classList.remove('dark-mode', 'dark');
-            toggle.textContent = '🌙';
         }
         // Sync Leaflet map tiles if map page is open
         if (typeof window.applyMapTheme === 'function') {
@@ -19,15 +19,24 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // Initialize theme from localStorage
-    const saved = localStorage.getItem(STORAGE_KEY);
-    applyTheme(saved === 'dark' ? 'dark' : 'light');
+    // Initialize theme from localStorage or default to system
+    const saved = localStorage.getItem(STORAGE_KEY) || 'system';
+    if (select) select.value = saved;
+    applyTheme(saved);
 
-    // Toggle theme on button click and store preference
-    toggle.addEventListener('click', () => {
-        const isDark = body.classList.contains('dark-mode');
-        const next = isDark ? 'light' : 'dark';
-        localStorage.setItem(STORAGE_KEY, next);
-        applyTheme(next);
+    // Change theme on selection and store preference
+    select?.addEventListener('change', (e) => {
+        const mode = e.target.value;
+        localStorage.setItem(STORAGE_KEY, mode);
+        applyTheme(mode);
+    });
+
+    // React to system preference changes when using system mode
+    prefersDark.addEventListener('change', () => {
+        const current = localStorage.getItem(STORAGE_KEY) || 'system';
+        if (current === 'system') {
+            applyTheme('system');
+        }
     });
 });
+


### PR DESCRIPTION
## Summary
- replace sun/moon button with dropdown for choosing theme
- support system color-scheme preference in new theme selector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ad66f0b8832e95d7328d5187e722