### PR TITLE
Add dark mode styling to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,16 +11,17 @@
         <link rel="stylesheet" href="assets/css/style.css" />
         <script src="https://cdn.tailwindcss.com"></script>
     </head>
-    <body class="text-stone-800">
+    <body class="text-stone-800 dark:text-stone-100">
         <div
             class="min-h-screen bg-cover bg-center flex items-center justify-center"
             style="background-image: url('https://images.unsplash.com/photo-1582878821849-6b1c7c2d16ff?auto=format&fit=crop&w=1950&q=80');"
         >
-            <div class="bg-white/80 p-8 rounded-xl text-center shadow-lg">
-                <h1 class="text-4xl md:text-5xl font-bold text-teal-800 mb-4">404 - הלכת לאיבוד!</h1>
-                <p class="text-lg text-stone-600 mb-6">נראה שדרקולה נשך את הקישור הזה.</p>
+            <div class="bg-white/80 dark:bg-slate-700/80 p-8 rounded-xl text-center shadow-lg">
+                <h1 class="text-4xl md:text-5xl font-bold text-teal-800 dark:text-teal-200 mb-4">404 - הלכת לאיבוד!</h1>
+                <p class="text-lg text-stone-600 dark:text-stone-300 mb-6">נראה שדרקולה נשך את הקישור הזה.</p>
                 <a href="/" class="nav-button">חזרה למסלול</a>
             </div>
         </div>
+        <script src="assets/js/theme.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- Adjust 404 page to match site theme in light and dark modes
- Load theme script and apply dark text and background styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f3064a04832ea6f43e40dba0d9cf