### PR TITLE
feat: add Romanian flag background theme

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -21,6 +21,18 @@ body {
     color: var(--text-color);
 }
 
+body.romanian-mode {
+    background: linear-gradient(
+        to right,
+        #002b7f 0%,
+        #002b7f 33.33%,
+        #fcd116 33.33%,
+        #fcd116 66.66%,
+        #ce1126 66.66%,
+        #ce1126 100%
+    );
+}
+
 .chart-container {
     position: relative;
     width: 100%;

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -8,10 +8,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Apply chosen theme classes based on mode
     function applyTheme(mode) {
         const theme = mode === 'system' ? (prefersDark.matches ? 'dark' : 'light') : mode;
+        body.classList.remove('dark-mode', 'dark', 'romanian-mode');
         if (theme === 'dark') {
             body.classList.add('dark-mode', 'dark');
-        } else {
-            body.classList.remove('dark-mode', 'dark');
+        } else if (theme === 'romanian') {
+            body.classList.add('romanian-mode');
         }
         // Sync Leaflet map tiles if map page is open
         if (typeof window.applyMapTheme === 'function') {

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
                     <option value="light">בהיר</option>
                     <option value="dark">כהה</option>
                     <option value="system">מערכת</option>
+                    <option value="romanian">דגל רומניה</option>
                 </select>
             </div>
             <!-- Main heading -->

--- a/pages/map.html
+++ b/pages/map.html
@@ -42,6 +42,7 @@
                     <option value="light">בהיר</option>
                     <option value="dark">כהה</option>
                     <option value="system">מערכת</option>
+                    <option value="romanian">דגל רומניה</option>
                 </select>
             </div>
             <!-- Embedded Google Map for the itinerary -->


### PR DESCRIPTION
## Summary
- add Romanian flag option to theme selector
- style body with Romanian flag gradient
- handle new theme in JavaScript theme manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899f7664f34832e8b9c369579e3c770